### PR TITLE
fix: Create temp crashed on first run

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func storePrevious(key, value string) error {
 
 func createTempDir() error {
 	err := os.Mkdir(path.Join(os.TempDir(), "sk"), os.ModePerm)
-	if strings.Contains(err.Error(), "file exists") {
+	if err == nil || strings.Contains(err.Error(), "file exists") {
 		return nil
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -19,3 +19,10 @@ func TestReadPrevious(t *testing.T) {
 	previous := readPrevious("testing")
 	assert.Equal(t, v, previous)
 }
+
+func TestCreateMultiplTempDirs(t *testing.T) {
+	err := createTempDir()
+	assert.NoError(t, err)
+	err = createTempDir()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
The sk tool crashes during first run when creating the temp dir.
Nil error is of course also a good scenario :)